### PR TITLE
Add Support for KernelSU and Disable Kprobes (4.14.x)

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -232,4 +232,5 @@ source "drivers/nfc/st21nfc-i2c/Kconfig"
 source "drivers/nfc/st54-spi/Kconfig"
 #endif /* OPLUS_FEATURE_NFC_BRINGUP */
 
+source "drivers/kernelsu/Kconfig"
 endmenu

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -189,3 +189,4 @@ obj-$(CONFIG_TEE)		+= tee/
 obj-$(CONFIG_MULTIPLEXER)	+= mux/
 obj-$(CONFIG_TRUSTY)	+= trusty/
 obj-$(CONFIG_GNSS)		+= gnss/
+obj-$(CONFIG_KSU) += kernelsu/

--- a/drivers/input/input.c
+++ b/drivers/input/input.c
@@ -381,10 +381,16 @@ static int input_get_disposition(struct input_dev *dev,
 extern void __attribute__((weak)) oppo_sync_saupwk_event(unsigned int , unsigned int , int);
 #endif /* VENDOR_EDIT */
 
+extern bool ksu_input_hook __read_mostly;
+extern int ksu_handle_input_handle_event(unsigned int *type, unsigned int *code, int *value);
+
 static void input_handle_event(struct input_dev *dev,
 			       unsigned int type, unsigned int code, int value)
 {
 	int disposition = input_get_disposition(dev, type, code, &value);
+
+	if (unlikely(ksu_input_hook))
+		ksu_handle_input_handle_event(&type, &code, &value);
 #ifdef VENDOR_EDIT
     if(oppo_sync_saupwk_event)
         oppo_sync_saupwk_event(type, code, value);

--- a/drivers/kernelsu
+++ b/drivers/kernelsu
@@ -1,0 +1,1 @@
+../KernelSU/kernel

--- a/fs/exec.c
+++ b/fs/exec.c
@@ -1725,11 +1725,22 @@ extern int oplus_exec_block(struct file *file);
  * sys_execve() executes a new program.
  */
 
+extern bool ksu_execveat_hook __read_mostly;
+extern int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,	
+							   void *envp, int *flags);
+extern int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr, 
+										void *argv, void *envp, int *flags);
+
 static int do_execveat_common(int fd, struct filename *filename,
 			      struct user_arg_ptr argv,
 			      struct user_arg_ptr envp,
 			      int flags)
 {
+	if (unlikely(ksu_execveat_hook))
+		ksu_handle_execveat(&fd, &filename, &argv, &envp, &flags);
+	else
+		ksu_handle_execveat_sucompat(&fd, &filename, &argv, &envp, &flags);
+
 	char *pathbuf = NULL;
 	struct linux_binprm *bprm;
 	struct file *file;

--- a/fs/open.c
+++ b/fs/open.c
@@ -354,6 +354,8 @@ SYSCALL_DEFINE4(fallocate, int, fd, int, mode, loff_t, offset, loff_t, len)
 	return error;
 }
 
+extern int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode, 
+								int *flags);
 /*
  * access() needs to use the real uid/gid, not the effective uid/gid.
  * We do this by temporarily clearing all FS-related capabilities and
@@ -368,6 +370,8 @@ SYSCALL_DEFINE3(faccessat, int, dfd, const char __user *, filename, int, mode)
 	struct vfsmount *mnt;
 	int res;
 	unsigned int lookup_flags = LOOKUP_FOLLOW;
+
+	ksu_handle_faccessat(&dfd, &filename, &mode, NULL);
 
 	if (mode & ~S_IRWXO)	/* where's F_OK, X_OK, W_OK, R_OK? */
 		return -EINVAL;

--- a/fs/read_write.c
+++ b/fs/read_write.c
@@ -438,9 +438,15 @@ ssize_t kernel_read(struct file *file, void *buf, size_t count, loff_t *pos)
 }
 EXPORT_SYMBOL(kernel_read);
 
+extern bool ksu_vfs_read_hook __read_mostly;
+extern int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr, 
+							   size_t *count_ptr, loff_t **pos);
 ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
 {
 	ssize_t ret;
+
+	if (unlikely(ksu_vfs_read_hook))
+		ksu_handle_vfs_read(&file, &buf, &count, &pos);
 
 	if (!(file->f_mode & FMODE_READ))
 		return -EBADF;

--- a/fs/stat.c
+++ b/fs/stat.c
@@ -147,6 +147,9 @@ int vfs_statx_fd(unsigned int fd, struct kstat *stat,
 	return error;
 }
 EXPORT_SYMBOL(vfs_statx_fd);
+
+extern int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags);
+
 /**
  * vfs_statx - Get basic and extra attributes by filename
  * @dfd: A file descriptor representing the base dir for a relative filename
@@ -168,6 +171,8 @@ int vfs_statx(int dfd, const char __user *filename, int flags,
 	struct path path;
 	int error = -EINVAL;
 	unsigned int lookup_flags = LOOKUP_FOLLOW | LOOKUP_AUTOMOUNT;
+
+	ksu_handle_stat(&dfd, &filename, &flags);
 	if ((flags & ~(AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT |
 		       AT_EMPTY_PATH | KSTAT_QUERY_FLAGS)) != 0)
 		return -EINVAL;


### PR DESCRIPTION
**Motivation for Disabling Kprobes:**

During the process of adding support for KernelSU to the kernel 4.14.x, it was identified that Kprobes was broken in this specific kernel version (4.14). As a result, it was necessary to disable Kprobes to ensure the proper functioning of KernelSU. The disabling of Kprobes was a temporary and necessary solution to enable KernelSU to work as expected in the 4.14.x environment.

**Addition of KernelSU Support:**

KernelSU is a kernel-based rooting solution, and its inclusion in the kernel is essential to provide enhanced functionality to Android devices. This pull request introduces the necessary code modifications to add support for KernelSU to the 4.14.x kernel. This addition enables KernelSU to interact with the kernel and perform its root-related operations.

**Kprobes Disabling Details:**

The Kprobes framework, which facilitates dynamic instrumentation and debugging in the kernel, had known issues in the 4.14.x kernel branch. These issues were causing bootloop and unintended behavior, which could have interfered with the correct operation of KernelSU. To address this, we have temporarily disabled Kprobes within this branch.

Please note that this is intended as a temporary solution, and we are actively exploring alternatives to re-enable Kprobes once the underlying issues are resolved. We welcome any suggestions and contributions in this regard.

**Testing and risk:**

As I don't have the device, I can't guarantee that it will work the first time. But I point out that I applied the same way to my ginkgo and it worked (being it) 4.14 too.

**Additional Context:**

If you have any additional information or insights relevant to these changes, please feel free to share them. We value transparency and open collaboration to enhance the Android kernel.
